### PR TITLE
FIX: support multiple attachments

### DIFF
--- a/src/JiraClient.php
+++ b/src/JiraClient.php
@@ -397,6 +397,7 @@ class JiraClient
             } else {
                 $results[$idx] = $response;
             }
+            $idx++;
         }
 
         curl_close($ch);


### PR DESCRIPTION
When uploading multiple attachments to Jira, this will work - but the feedback doesn't correspond with the uploaded files.